### PR TITLE
Fix facebook link

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
               <i class="fa fa-twitter fa-stack-1x"></i>
             </span>
           </a>
-          <a href="https://facebook.com/cesiuminho" target="_blank">
+          <a href="https://facebook.com/SEI.UMinho" target="_blank">
             <span class="fa-stack fa-md">
               <i class="fa fa-circle-thin fa-stack-2x"></i>
               <i class="fa fa-facebook fa-stack-1x"></i>


### PR DESCRIPTION
Prior to this change, the facebook icon was redirecting to CeSIUM's
facebook.