### PR TITLE
fix: remove blue highlighting box on button click

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,11 @@ canvas {
   overflow: hidden;
 }
 
+button {
+  -webkit-tap-highlight-color: transparent;
+  outline: none;
+}
+
 @font-face {
   font-family: "Inter-Regular";
   src: url("/fonts/Inter/Inter-Regular.ttf") format("truetype");


### PR DESCRIPTION
On some browsers (specifically while on a mobile phone), when clicking a button, a blue highlighting box appears. This PR intends to remove that behaviour.

Code gathered from [this stack overflow thread](https://stackoverflow.com/questions/45049873/how-to-remove-the-blue-highlight-of-button-on-mobile).